### PR TITLE
ci: run marketplace-app-check on every PR, gated internally by apps.json diff

### DIFF
--- a/.github/workflows/marketplace-app-check.yml
+++ b/.github/workflows/marketplace-app-check.yml
@@ -2,8 +2,6 @@ name: Marketplace App Check
 
 on:
   pull_request:
-    paths:
-      - "apps.json"
 
 jobs:
   semgrep-check:
@@ -14,7 +12,24 @@ jobs:
         with:
           fetch-depth: 0
 
+      # Runs on every PR (no `paths:` filter) so it can be a required status
+      # check on main - a required check that only triggers on some paths
+      # never reports on other PRs and blocks them forever. This step keeps
+      # the job itself fast/green for PRs that don't touch apps.json instead.
+      - name: Check whether apps.json changed
+        id: diff
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          if git diff --name-only "$BASE_SHA" "$HEAD_SHA" | grep -qx "apps.json"; then
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Ensure PR is up to date with ${{ github.event.pull_request.base.ref }}
+        if: steps.diff.outputs.changed == 'true'
         env:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
@@ -25,27 +40,33 @@ jobs:
           fi
 
       - uses: actions/setup-python@v5
+        if: steps.diff.outputs.changed == 'true'
         with:
           python-version: "3.13"
 
       - name: Install uv
+        if: steps.diff.outputs.changed == 'true'
         run: |
           curl -LsSf https://astral.sh/uv/install.sh | sh
           echo "$HOME/.local/bin" >> $GITHUB_PATH
 
       - name: Install semgrep
+        if: steps.diff.outputs.changed == 'true'
         run: uv tool install semgrep
 
       - name: Install pilot
+        if: steps.diff.outputs.changed == 'true'
         # Pinned to a commit, not @main — a floating ref here means a pilot
         # change and a bug in this script could land at the same time,
         # making failures here much harder to diagnose. Bump deliberately.
         run: pip install git+https://github.com/frappe/pilot@ae13b2b949588b4701b99de7b463f995b7df81e9
 
       - name: Get base apps.json
+        if: steps.diff.outputs.changed == 'true'
         run: git show ${{ github.event.pull_request.base.sha }}:apps.json > /tmp/apps_before.json
 
       - name: Check changed marketplace apps
+        if: steps.diff.outputs.changed == 'true'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: python3 scripts/check_marketplace_apps.py /tmp/apps_before.json apps.json

--- a/scripts/run_get_app_validation.py
+++ b/scripts/run_get_app_validation.py
@@ -22,9 +22,9 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).parent))
 from validator import Validator
 
-from pilot.config.app_config import AppConfig
+from pilot.config import AppConfig
 from pilot.core.app import App
-from pilot.core.app_validator import Validator as InstallValidator
+from pilot.core.app.validator import Validator as InstallValidator
 from pilot.exceptions import AppValidationError, BenchError
 
 FRAPPE_REPO = "https://github.com/frappe/frappe"


### PR DESCRIPTION
## Summary
- `Marketplace App Check` only triggers via `paths: - apps.json`, so a required status check based on it would never report (and would block merges forever) on PRs that don't touch `apps.json`. Drops the path filter so the workflow runs on every PR, and adds a `Check whether apps.json changed` step that gates the semgrep/app-validator steps behind an `if:` — PRs that don't touch `apps.json` get a fast no-op green, PRs that do get the full check. Prep for turning on branch protection on `main` requiring this check.
- `scripts/run_get_app_validation.py`: updated two imports for pilot's current module layout — `AppConfig` moved from `pilot.config.app_config` to `pilot.config`, and the app `Validator` from `pilot.core.app_validator` to `pilot.core.app.validator`.

## Test plan
- [ ] Open this PR and confirm the workflow job reports green quickly (no apps.json change here)
- [ ] Open a throwaway PR touching `apps.json` and confirm the full semgrep + validator steps still run
- [ ] Confirm `run_get_app_validation.py` imports resolve against current `pilot`