### PR TITLE
feat: Add frappe suite to marketplace

### DIFF
--- a/apps.json
+++ b/apps.json
@@ -5685,5 +5685,28 @@
     "category": "Applications",
     "stars": 93,
     "targets": []
+  },
+  {
+    "name": "suite",
+    "title": "Frappe Suite",
+    "description": "Drive, Slides, Writer, Sheets, Meet, Mail and Calendar in one app",
+    "repo": "https://github.com/frappe/suite",
+    "logo_url": "https://raw.githubusercontent.com/frappe/suite/develop/frontend/public/logo.svg",
+    "website": "https://frappe.io",
+    "documentation": "https://docs.frappe.io",
+    "categories": [
+      "Productivity"
+    ],
+    "category": "Applications",
+    "stars": 56,
+    "targets": [
+      {
+        "version": "0.0.1",
+        "target_type": "branch",
+        "target": "develop",
+        "frappe_core": ">=16.0.0,<18.0.0",
+        "dependencies": {}
+      }
+    ]
   }
 ]

--- a/apps.json
+++ b/apps.json
@@ -5689,7 +5689,7 @@
   {
     "name": "suite",
     "title": "Frappe Suite",
-    "description": "Drive, Slides, Writer, Sheets, Meet, Mail and Calendar in one app",
+    "description": "Original, intentionally designed productivity tools",
     "repo": "https://github.com/frappe/suite",
     "logo_url": "https://raw.githubusercontent.com/frappe/suite/develop/frontend/public/logo.svg",
     "website": "https://frappe.io",


### PR DESCRIPTION
Adds [frappe/suite](https://github.com/frappe/suite) to the registry, and exercises the automated checks end to end.

Replaces #2, which branched from history that no longer shares an ancestor with `main`. That PR ran the old `scripts/` workflow from its own head branch (failing on `ModuleNotFoundError: No module named 'packaging'`), and could never pass the "up to date with main" gate. This branch is cut from current `main`, so CI runs the `validation/` suite.

Entry details:
- `frappe_core` is `>=16.0.0,<18.0.0`, taken from `[tool.bench.frappe-dependencies]` in the app's `pyproject.toml`
- targets the `develop` branch at version `0.0.1`
- `validation/schema_check.py` passes locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)