### PR TITLE
ci: bump pinned pilot commit so validation imports resolve

### DIFF
--- a/.github/workflows/marketplace-app-check.yml
+++ b/.github/workflows/marketplace-app-check.yml
@@ -56,10 +56,10 @@ jobs:
 
       - name: Install pilot
         if: steps.diff.outputs.changed == 'true'
-        # Pinned to a commit, not @main — a floating ref here means a pilot
-        # change and a bug in this script could land at the same time,
+        # Pinned to a release tag, not @main — a floating ref here means a
+        # pilot change and a bug in this script could land at the same time,
         # making failures here much harder to diagnose. Bump deliberately.
-        run: pip install git+https://github.com/frappe/pilot@ae13b2b949588b4701b99de7b463f995b7df81e9
+        run: pip install git+https://github.com/frappe/pilot@v0.0.9-pre-alpha
 
       - name: Get base apps.json
         if: steps.diff.outputs.changed == 'true'


### PR DESCRIPTION
Every `apps.json` PR fails in `semgrep-check` before any validation runs:

```
File "validation/get_app_check.py", line 25, in <module>
    from pilot.config import AppConfig
ImportError: cannot import name 'AppConfig' from 'pilot.config'
```

The pinned `ae13b2b9` predates three of the four symbols `get_app_check.py` imports — `AppConfig`, `App` and `Validator`. Pilot's `d5fe6740` moved `AppConfig` to `pilot.config.app` and re-exported it; the pin was never bumped to match.

Pins to the `v0.0.9-pre-alpha` release, where all four imports resolve. A tag over a bare SHA: it says which pilot the checks ran against without a lookup, and releases are what users actually install. Still deliberate, not a floating ref.

Note: this PR doesn't touch `apps.json`, so the workflow's own diff gate skips the real steps — a green run here doesn't exercise the fix. #6 is the first real test, once this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)