### PR TITLE
ci: report app check findings on the PR

### DIFF
--- a/.github/scripts/post_report.sh
+++ b/.github/scripts/post_report.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# Publish the app check report: to the run summary, and as a single PR comment
+# that later runs edit in place.
+#
+# Usage: post_report.sh <report.md>
+# Env:   PR, HEAD_SHA, GITHUB_REPOSITORY, GITHUB_TOKEN, GITHUB_STEP_SUMMARY
+
+set -euo pipefail
+
+REPORT=${1:?usage: post_report.sh <report.md>}
+MARKER='<!-- marketplace-app-check'
+
+if [ ! -f "$REPORT" ]; then
+  echo "No report written — the check crashed before scanning."
+  exit 0
+fi
+
+# Per-run, so always safe to write.
+if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
+  cat "$REPORT" >> "$GITHUB_STEP_SUMMARY"
+fi
+
+# The last comment carrying the marker is this check's own. Matching on it
+# rather than "the bot's last comment" avoids overwriting an unrelated one.
+existing_comment() {
+  gh api "repos/$GITHUB_REPOSITORY/issues/$PR/comments" --paginate \
+    --jq ".[] | select(.body | startswith(\"$MARKER\")) | \"\(.id) \(.body | split(\"\n\")[0])\"" |
+    tail -1
+}
+
+# Whether this run may write is decided by ancestry rather than by timing, so
+# it cannot go stale between the check and the write: the commit a report
+# describes is recorded in its marker.
+may_write() {
+  local posted=$1
+  [ -z "$posted" ] && return 0                                    # pre-marker comment
+  [ "$posted" = "$HEAD_SHA" ] && return 0
+  git fetch --no-tags --quiet origin "$posted" 2>/dev/null || true
+  git merge-base --is-ancestor "$posted" "$HEAD_SHA" 2>/dev/null && return 0
+  git merge-base --is-ancestor "$HEAD_SHA" "$posted" 2>/dev/null && return 1
+  # Neither descends from the other: the branch was rebased or force pushed, or
+  # this run is for a commit since rewritten away. Whoever is the tip now owns
+  # the report — otherwise a rewritten head would leave old findings up for good.
+  [ "$(gh pr view "$PR" --json headRefOid --jq .headRefOid)" = "$HEAD_SHA" ]
+}
+
+existing=$(existing_comment)
+comment_id=${existing%% *}
+posted_sha=$(printf '%s' "$existing" | sed -n "s/.*marketplace-app-check \([0-9a-f]\{40\}\) -->.*/\1/p")
+
+if ! may_write "$posted_sha"; then
+  echo "A report for $posted_sha already covers this branch; leaving it alone."
+  exit 0
+fi
+
+jq -Rs '{body: .}' "$REPORT" > /tmp/comment.json
+
+# Fork PRs get a read-only token; the run summary is the fallback there.
+if [ -n "$comment_id" ]; then
+  gh api -X PATCH "repos/$GITHUB_REPOSITORY/issues/comments/$comment_id" \
+    --input /tmp/comment.json --silent ||
+    echo "Could not update the PR comment (expected for forks); see the job summary."
+else
+  gh api -X POST "repos/$GITHUB_REPOSITORY/issues/$PR/comments" \
+    --input /tmp/comment.json --silent ||
+    echo "Could not comment on the PR (expected for forks); see the job summary."
+fi

--- a/.github/scripts/post_report.sh
+++ b/.github/scripts/post_report.sh
@@ -9,6 +9,8 @@ set -euo pipefail
 
 REPORT=${1:?usage: post_report.sh <report.md>}
 MARKER='<!-- marketplace-app-check'
+ATTEMPTS=${POST_REPORT_ATTEMPTS:-3}
+RECHECK_DELAY=${POST_REPORT_RECHECK_DELAY:-2}
 
 if [ ! -f "$REPORT" ]; then
   echo "No report written — the check crashed before scanning."
@@ -28,6 +30,10 @@ existing_comment() {
     tail -1
 }
 
+marker_sha() {
+  printf '%s' "$1" | sed -n "s/.*marketplace-app-check \([0-9a-f]\{40\}\) -->.*/\1/p"
+}
+
 # Whether this run may write is decided by ancestry rather than by timing, so
 # it cannot go stale between the check and the write: the commit a report
 # describes is recorded in its marker.
@@ -44,24 +50,44 @@ may_write() {
   [ "$(gh pr view "$PR" --json headRefOid --jq .headRefOid)" = "$HEAD_SHA" ]
 }
 
-existing=$(existing_comment)
-comment_id=${existing%% *}
-posted_sha=$(printf '%s' "$existing" | sed -n "s/.*marketplace-app-check \([0-9a-f]\{40\}\) -->.*/\1/p")
-
-if ! may_write "$posted_sha"; then
-  echo "A report for $posted_sha already covers this branch; leaving it alone."
-  exit 0
-fi
+# Fork PRs get a read-only token; the run summary is the fallback there.
+write_comment() {
+  local id=$1
+  if [ -n "$id" ]; then
+    gh api -X PATCH "repos/$GITHUB_REPOSITORY/issues/comments/$id" \
+      --input /tmp/comment.json --silent
+  else
+    gh api -X POST "repos/$GITHUB_REPOSITORY/issues/$PR/comments" \
+      --input /tmp/comment.json --silent
+  fi
+}
 
 jq -Rs '{body: .}' "$REPORT" > /tmp/comment.json
 
-# Fork PRs get a read-only token; the run summary is the fallback there.
-if [ -n "$comment_id" ]; then
-  gh api -X PATCH "repos/$GITHUB_REPOSITORY/issues/comments/$comment_id" \
-    --input /tmp/comment.json --silent ||
-    echo "Could not update the PR comment (expected for forks); see the job summary."
-else
-  gh api -X POST "repos/$GITHUB_REPOSITORY/issues/$PR/comments" \
-    --input /tmp/comment.json --silent ||
-    echo "Could not comment on the PR (expected for forks); see the job summary."
-fi
+# GitHub has no compare-and-swap for comments — If-Match is rejected outright —
+# so a write cannot be made conditional. Instead, confirm afterwards that the
+# comment still shows this run's commit, and re-assert if an older run
+# overwrote it. The older run stops as soon as it sees its own commit posted,
+# so this settles on the newest report rather than on whoever wrote last.
+for attempt in $(seq "$ATTEMPTS"); do
+  existing=$(existing_comment)
+  posted_sha=$(marker_sha "$existing")
+
+  if ! may_write "$posted_sha"; then
+    echo "A report for $posted_sha already covers this branch; leaving it alone."
+    exit 0
+  fi
+
+  if ! write_comment "${existing%% *}"; then
+    echo "Could not write the PR comment (expected for forks); see the job summary."
+    exit 0
+  fi
+
+  [ -z "$HEAD_SHA" ] && exit 0
+  sleep "$RECHECK_DELAY"
+  posted_sha=$(marker_sha "$(existing_comment)")
+  [ "$posted_sha" = "$HEAD_SHA" ] && exit 0
+  echo "Comment now shows $posted_sha, not $HEAD_SHA — re-checking (attempt $attempt)."
+done
+
+echo "Gave up re-asserting the report after $ATTEMPTS attempts; the next run will correct it."

--- a/.github/workflows/marketplace-app-check.yml
+++ b/.github/workflows/marketplace-app-check.yml
@@ -3,6 +3,10 @@ name: Marketplace App Check
 on:
   pull_request:
 
+permissions:
+  contents: read
+  pull-requests: write # to post the findings report as a PR comment
+
 jobs:
   semgrep-check:
     runs-on: ubuntu-22.04
@@ -69,4 +73,19 @@ jobs:
         if: steps.diff.outputs.changed == 'true'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: python3 validation/check.py /tmp/apps_before.json apps.json
+        run: python3 validation/check.py /tmp/apps_before.json apps.json --report /tmp/report.md
+
+      # always(): the report matters most when the checks failed.
+      - name: Report findings on the PR
+        if: always() && steps.diff.outputs.changed == 'true'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR: ${{ github.event.pull_request.number }}
+        run: |
+          [ -f /tmp/report.md ] || { echo "No report written — the check crashed before scanning."; exit 0; }
+          cat /tmp/report.md >> "$GITHUB_STEP_SUMMARY"
+          # Fork PRs get a read-only token, so commenting fails there by
+          # design — the job summary above is the fallback, and the job's own
+          # pass/fail is unaffected either way.
+          gh pr comment "$PR" --body-file /tmp/report.md --edit-last --create-if-none \
+            || echo "Could not comment on the PR (expected for forks); see the job summary."

--- a/.github/workflows/marketplace-app-check.yml
+++ b/.github/workflows/marketplace-app-check.yml
@@ -7,9 +7,8 @@ permissions:
   contents: read
   pull-requests: write # to post the findings report as a PR comment
 
-# One run per PR. Without this, a slow run for an older commit can finish
-# after a newer one and overwrite its comment, leaving the PR showing
-# findings for code that is no longer there.
+# One run per PR, so a slow older run cannot finish last and overwrite a
+# newer run's comment with stale findings.
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
   cancel-in-progress: true
@@ -84,10 +83,8 @@ jobs:
           python3 validation/check.py /tmp/apps_before.json apps.json \
             --report /tmp/report.md --commit "${{ github.event.pull_request.head.sha }}"
 
-      # !cancelled() rather than always(): the report matters most when the
-      # checks failed, but a run cancelled by a newer push must stay quiet —
-      # always() is true for cancelled runs too, so it would let a superseded
-      # run post its now-stale findings over the newer run's comment.
+      # !cancelled(), not always(): failures must report, but a superseded
+      # run must stay quiet — always() is true for cancelled runs too.
       - name: Report findings on the PR
         if: ${{ !cancelled() && steps.diff.outputs.changed == 'true' }}
         env:
@@ -99,17 +96,13 @@ jobs:
           # The summary is per-run, so it is always safe to write.
           cat /tmp/report.md >> "$GITHUB_STEP_SUMMARY"
 
-          # Cancellation cannot stop this step once it has started, so check
-          # at write time that the branch still points at the commit this
-          # report describes. Without it a superseded run that got this far
-          # would overwrite a newer run's comment with stale findings.
+          # Cancellation cannot stop this step once started, so confirm the
+          # branch still points at the commit this report describes.
           CURRENT_SHA=$(gh pr view "$PR" --json headRefOid --jq .headRefOid)
           if [ "$CURRENT_SHA" != "$HEAD_SHA" ]; then
             echo "Head moved $HEAD_SHA -> $CURRENT_SHA; leaving the comment to the newer run."
             exit 0
           fi
-          # Fork PRs get a read-only token, so commenting fails there by
-          # design — the job summary above is the fallback, and the job's own
-          # pass/fail is unaffected either way.
+          # Fork PRs get a read-only token; the summary above is the fallback.
           gh pr comment "$PR" --body-file /tmp/report.md --edit-last --create-if-none \
             || echo "Could not comment on the PR (expected for forks); see the job summary."

--- a/.github/workflows/marketplace-app-check.yml
+++ b/.github/workflows/marketplace-app-check.yml
@@ -93,9 +93,21 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR: ${{ github.event.pull_request.number }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
           [ -f /tmp/report.md ] || { echo "No report written — the check crashed before scanning."; exit 0; }
+          # The summary is per-run, so it is always safe to write.
           cat /tmp/report.md >> "$GITHUB_STEP_SUMMARY"
+
+          # Cancellation cannot stop this step once it has started, so check
+          # at write time that the branch still points at the commit this
+          # report describes. Without it a superseded run that got this far
+          # would overwrite a newer run's comment with stale findings.
+          CURRENT_SHA=$(gh pr view "$PR" --json headRefOid --jq .headRefOid)
+          if [ "$CURRENT_SHA" != "$HEAD_SHA" ]; then
+            echo "Head moved $HEAD_SHA -> $CURRENT_SHA; leaving the comment to the newer run."
+            exit 0
+          fi
           # Fork PRs get a read-only token, so commenting fails there by
           # design — the job summary above is the fallback, and the job's own
           # pass/fail is unaffected either way.

--- a/.github/workflows/marketplace-app-check.yml
+++ b/.github/workflows/marketplace-app-check.yml
@@ -103,6 +103,22 @@ jobs:
             echo "Head moved $HEAD_SHA -> $CURRENT_SHA; leaving the comment to the newer run."
             exit 0
           fi
+          # Find this check's own comment by its marker and edit that one, so
+          # a PR carries a single report however many times CI runs. Matching
+          # on the marker rather than "the bot's last comment" keeps it from
+          # overwriting some other comment the same bot made.
+          MARKER='<!-- marketplace-app-check -->'
+          jq -Rs '{body: .}' /tmp/report.md > /tmp/comment.json
+          EXISTING=$(gh api "repos/$GITHUB_REPOSITORY/issues/$PR/comments" --paginate \
+            --jq ".[] | select(.body | startswith(\"$MARKER\")) | .id" | tail -1)
+
           # Fork PRs get a read-only token; the summary above is the fallback.
-          gh pr comment "$PR" --body-file /tmp/report.md --edit-last --create-if-none \
-            || echo "Could not comment on the PR (expected for forks); see the job summary."
+          if [ -n "$EXISTING" ]; then
+            gh api -X PATCH "repos/$GITHUB_REPOSITORY/issues/comments/$EXISTING" \
+              --input /tmp/comment.json --silent \
+              || echo "Could not update the PR comment (expected for forks); see the job summary."
+          else
+            gh api -X POST "repos/$GITHUB_REPOSITORY/issues/$PR/comments" \
+              --input /tmp/comment.json --silent \
+              || echo "Could not comment on the PR (expected for forks); see the job summary."
+          fi

--- a/.github/workflows/marketplace-app-check.yml
+++ b/.github/workflows/marketplace-app-check.yml
@@ -96,25 +96,34 @@ jobs:
           # The summary is per-run, so it is always safe to write.
           cat /tmp/report.md >> "$GITHUB_STEP_SUMMARY"
 
-          # Cancellation cannot stop this step once started, so confirm the
-          # branch still points at the commit this report describes.
-          CURRENT_SHA=$(gh pr view "$PR" --json headRefOid --jq .headRefOid)
-          if [ "$CURRENT_SHA" != "$HEAD_SHA" ]; then
-            echo "Head moved $HEAD_SHA -> $CURRENT_SHA; leaving the comment to the newer run."
-            exit 0
-          fi
           # Find this check's own comment by its marker and edit that one, so
           # a PR carries a single report however many times CI runs. Matching
           # on the marker rather than "the bot's last comment" keeps it from
-          # overwriting some other comment the same bot made.
-          MARKER='<!-- marketplace-app-check -->'
+          # overwriting some other comment the same bot made. The marker names
+          # the commit each report describes.
+          MARKER='<!-- marketplace-app-check'
           jq -Rs '{body: .}' /tmp/report.md > /tmp/comment.json
           EXISTING=$(gh api "repos/$GITHUB_REPOSITORY/issues/$PR/comments" --paginate \
-            --jq ".[] | select(.body | startswith(\"$MARKER\")) | .id" | tail -1)
+            --jq ".[] | select(.body | startswith(\"$MARKER\")) | \"\(.id) \(.body | split(\"\n\")[0])\"" | tail -1)
+          EXISTING_ID=${EXISTING%% *}
+          POSTED_SHA=$(printf '%s' "$EXISTING" | sed -n 's/.*marketplace-app-check \([0-9a-f]\{40\}\) -->.*/\1/p')
+
+          # Whether this run may write is decided by ancestry, not by timing: a
+          # report may only be replaced by one for a descendant commit. Checking
+          # that the head still matches would leave a window between the check
+          # and the write; this cannot go stale, because the commit a report
+          # describes is recorded in the comment itself.
+          if [ -n "$POSTED_SHA" ] && [ "$POSTED_SHA" != "$HEAD_SHA" ]; then
+            git fetch --no-tags --quiet origin "$POSTED_SHA" 2>/dev/null || true
+            if ! git merge-base --is-ancestor "$POSTED_SHA" "$HEAD_SHA" 2>/dev/null; then
+              echo "Comment describes $POSTED_SHA, which $HEAD_SHA does not descend from; leaving it alone."
+              exit 0
+            fi
+          fi
 
           # Fork PRs get a read-only token; the summary above is the fallback.
-          if [ -n "$EXISTING" ]; then
-            gh api -X PATCH "repos/$GITHUB_REPOSITORY/issues/comments/$EXISTING" \
+          if [ -n "$EXISTING_ID" ]; then
+            gh api -X PATCH "repos/$GITHUB_REPOSITORY/issues/comments/$EXISTING_ID" \
               --input /tmp/comment.json --silent \
               || echo "Could not update the PR comment (expected for forks); see the job summary."
           else

--- a/.github/workflows/marketplace-app-check.yml
+++ b/.github/workflows/marketplace-app-check.yml
@@ -7,6 +7,13 @@ permissions:
   contents: read
   pull-requests: write # to post the findings report as a PR comment
 
+# One run per PR. Without this, a slow run for an older commit can finish
+# after a newer one and overwrite its comment, leaving the PR showing
+# findings for code that is no longer there.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 jobs:
   semgrep-check:
     runs-on: ubuntu-22.04
@@ -73,11 +80,16 @@ jobs:
         if: steps.diff.outputs.changed == 'true'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: python3 validation/check.py /tmp/apps_before.json apps.json --report /tmp/report.md
+        run: |
+          python3 validation/check.py /tmp/apps_before.json apps.json \
+            --report /tmp/report.md --commit "${{ github.event.pull_request.head.sha }}"
 
-      # always(): the report matters most when the checks failed.
+      # !cancelled() rather than always(): the report matters most when the
+      # checks failed, but a run cancelled by a newer push must stay quiet —
+      # always() is true for cancelled runs too, so it would let a superseded
+      # run post its now-stale findings over the newer run's comment.
       - name: Report findings on the PR
-        if: always() && steps.diff.outputs.changed == 'true'
+        if: ${{ !cancelled() && steps.diff.outputs.changed == 'true' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR: ${{ github.event.pull_request.number }}

--- a/.github/workflows/marketplace-app-check.yml
+++ b/.github/workflows/marketplace-app-check.yml
@@ -91,43 +91,4 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR: ${{ github.event.pull_request.number }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
-        run: |
-          [ -f /tmp/report.md ] || { echo "No report written — the check crashed before scanning."; exit 0; }
-          # The summary is per-run, so it is always safe to write.
-          cat /tmp/report.md >> "$GITHUB_STEP_SUMMARY"
-
-          # Find this check's own comment by its marker and edit that one, so
-          # a PR carries a single report however many times CI runs. Matching
-          # on the marker rather than "the bot's last comment" keeps it from
-          # overwriting some other comment the same bot made. The marker names
-          # the commit each report describes.
-          MARKER='<!-- marketplace-app-check'
-          jq -Rs '{body: .}' /tmp/report.md > /tmp/comment.json
-          EXISTING=$(gh api "repos/$GITHUB_REPOSITORY/issues/$PR/comments" --paginate \
-            --jq ".[] | select(.body | startswith(\"$MARKER\")) | \"\(.id) \(.body | split(\"\n\")[0])\"" | tail -1)
-          EXISTING_ID=${EXISTING%% *}
-          POSTED_SHA=$(printf '%s' "$EXISTING" | sed -n 's/.*marketplace-app-check \([0-9a-f]\{40\}\) -->.*/\1/p')
-
-          # Whether this run may write is decided by ancestry, not by timing: a
-          # report may only be replaced by one for a descendant commit. Checking
-          # that the head still matches would leave a window between the check
-          # and the write; this cannot go stale, because the commit a report
-          # describes is recorded in the comment itself.
-          if [ -n "$POSTED_SHA" ] && [ "$POSTED_SHA" != "$HEAD_SHA" ]; then
-            git fetch --no-tags --quiet origin "$POSTED_SHA" 2>/dev/null || true
-            if ! git merge-base --is-ancestor "$POSTED_SHA" "$HEAD_SHA" 2>/dev/null; then
-              echo "Comment describes $POSTED_SHA, which $HEAD_SHA does not descend from; leaving it alone."
-              exit 0
-            fi
-          fi
-
-          # Fork PRs get a read-only token; the summary above is the fallback.
-          if [ -n "$EXISTING_ID" ]; then
-            gh api -X PATCH "repos/$GITHUB_REPOSITORY/issues/comments/$EXISTING_ID" \
-              --input /tmp/comment.json --silent \
-              || echo "Could not update the PR comment (expected for forks); see the job summary."
-          else
-            gh api -X POST "repos/$GITHUB_REPOSITORY/issues/$PR/comments" \
-              --input /tmp/comment.json --silent \
-              || echo "Could not comment on the PR (expected for forks); see the job summary."
-          fi
+        run: .github/scripts/post_report.sh /tmp/report.md

--- a/README.md
+++ b/README.md
@@ -98,3 +98,17 @@ runs two checks, in order:
    broken repo structure, syntax errors, undeclared `[tool.bench.frappe-dependencies]`/`required_apps`
    mismatches, and missing imports/dependencies that only show up once the
    app is actually installed.
+
+### Reading the results
+
+CI posts a report as a comment on your PR — one comment, edited in place on
+each push — and repeats it in the workflow run's summary. It lists every
+finding grouped by rule, with severity and `file:line` locations, so you
+shouldn't need to open the raw job log.
+
+Severities are `Critical`, `Major`, `Minor` and `Info`. **Critical and Major
+block the merge**; Minor and Info are advisory and are listed under a
+collapsed "advisory findings" section.
+
+PRs from forks get a read-only token, so the comment can't be posted there —
+the run summary carries the same report.

--- a/validation/check.py
+++ b/validation/check.py
@@ -7,11 +7,14 @@ at the first failure. A schema-failed app's targets are skipped entirely.
 Exits non-zero if anything fails.
 
 Run:
-    python3 validation/check.py <old-apps.json> <new-apps.json>
+    python3 validation/check.py <old-apps.json> <new-apps.json> [--report report.md]
+
+--report writes a markdown summary of every finding, for CI to post on the PR.
 """
 
 from __future__ import annotations
 
+import argparse
 import sys
 import tempfile
 from pathlib import Path
@@ -22,38 +25,45 @@ from schema_check import SchemaValidator
 from semgrep_check import SemgrepValidator
 from utils.clone import clone_app
 from utils.diff import find_changed_targets, load_apps
+from utils.report import CheckResult, Finding, Report, Section
 
 
 def changed_apps(old_apps: dict[str, dict], new_apps: dict[str, dict]) -> dict[str, dict]:
     return {name: app for name, app in new_apps.items() if old_apps.get(name) != app}
 
 
-def check_app_schema(name: str, app: dict) -> bool:
+def check_app_schema(name: str, app: dict, section: Section) -> bool:
     """Gate a changed app's schema before any of its targets are cloned."""
     print(f"\n=== Checking {name} (schema) ===", flush=True)
-    return SchemaValidator(app).run()
+    validator = SchemaValidator(app)
+    passed = validator.run()
+    section.checks.append(_result(validator, passed))
+    return passed
 
 
-def check_target(target: dict) -> bool:
+def check_target(target: dict, section: Section) -> bool:
     print(f"\n=== Checking {target['name']} ({target.get('repo')}@{target.get('target')}) ===", flush=True)
 
     with tempfile.TemporaryDirectory() as tmp:
         clone_dir = Path(tmp) / "app"
-        if not _clone(target, clone_dir):
+        if not _clone(target, clone_dir, section):
             return False
-        return _run_post_clone_checks(target, clone_dir)
+        return _run_post_clone_checks(target, clone_dir, section)
 
 
-def _clone(target: dict, clone_dir: Path) -> bool:
+def _clone(target: dict, clone_dir: Path, section: Section) -> bool:
     try:
         clone_app(target["repo"], target["target"], target["target_type"], clone_dir)
         return True
     except RuntimeError as exc:
         print(f"  FAIL: {exc}")
+        section.checks.append(
+            CheckResult(name="clone", status="failed", findings=[Finding(message=str(exc))])
+        )
         return False
 
 
-def _run_post_clone_checks(target: dict, clone_dir: Path) -> bool:
+def _run_post_clone_checks(target: dict, clone_dir: Path, section: Section) -> bool:
     """Run clone-dependent checks in order, stopping at the first failure."""
     repo, ref = target["repo"], target["target"]
     checks = [
@@ -63,33 +73,57 @@ def _run_post_clone_checks(target: dict, clone_dir: Path) -> bool:
     failed_at: str | None = None
     for name, check in checks:
         if failed_at is not None:
-            print(f"\n--- {name} ---\n  SKIPPED — {failed_at} failed for this target.")
+            print(f"\n--- {check.name} ---\n  SKIPPED — {failed_at} failed for this target.")
+            section.checks.append(CheckResult(name=check.name, status="skipped"))
             continue
-        if not check.run():
+        passed = check.run()
+        section.checks.append(_result(check, passed))
+        if not passed:
             failed_at = name
     return failed_at is None
 
 
-def main() -> None:
-    if len(sys.argv) != 3:
-        print("Usage: validation/check.py <old-apps.json> <new-apps.json>", file=sys.stderr)
-        sys.exit(1)
+def _result(validator, passed: bool) -> CheckResult:
+    return CheckResult(
+        name=validator.name,
+        status="passed" if passed else "failed",
+        findings=list(validator.findings),
+        notes=list(validator.notes),
+    )
 
-    marketplace = load_apps(Path(sys.argv[1]))
-    new_apps = load_apps(Path(sys.argv[2]))
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Run the marketplace app checks over an apps.json change.")
+    parser.add_argument("old_apps", type=Path, help="apps.json at the base revision")
+    parser.add_argument("new_apps", type=Path, help="apps.json as proposed")
+    parser.add_argument("--report", type=Path, help="write a markdown report of all findings here")
+    args = parser.parse_args()
+
+    marketplace = load_apps(args.old_apps)
+    new_apps = load_apps(args.new_apps)
+    report = Report()
 
     apps = changed_apps(marketplace, new_apps)
     if not apps:
         print("No app code changes detected — nothing to scan.")
+        _write_report(report, args.report)
         return
 
-    schema_failed = {name for name, app in apps.items() if not check_app_schema(name, app)}
+    sections = {name: report.section(name) for name in apps}
+    schema_failed = {name for name, app in apps.items() if not check_app_schema(name, app, sections[name])}
 
     # Excluded before find_changed_targets(), not filtered after - it
     # indexes app["repo"] directly and would crash on a schema-broken app.
     valid_new_apps = {name: app for name, app in new_apps.items() if name not in schema_failed}
     changed_targets = find_changed_targets(marketplace, valid_new_apps)
-    target_results = {f"{t['name']}@{t['target']}": check_target(t) for t in changed_targets}
+    target_results = {}
+    for target in changed_targets:
+        section = report.section(
+            f"{target['name']}@{target['target']}", subtitle=f"{target.get('repo')}@{target.get('target')}"
+        )
+        target_results[f"{target['name']}@{target['target']}"] = check_target(target, section)
+
+    _write_report(report, args.report)
 
     failed = sorted(schema_failed) + [key for key, passed in target_results.items() if not passed]
     if failed:
@@ -97,6 +131,13 @@ def main() -> None:
         sys.exit(1)
 
     print(f"\nAll {len(apps)} changed app(s) passed.")
+
+
+def _write_report(report: Report, path: Path | None) -> None:
+    if path is None:
+        return
+    path.write_text(report.render())
+    print(f"\nWrote report to {path}")
 
 
 if __name__ == "__main__":

--- a/validation/check.py
+++ b/validation/check.py
@@ -7,7 +7,7 @@ at the first failure. A schema-failed app's targets are skipped entirely.
 Exits non-zero if anything fails.
 
 Run:
-    python3 validation/check.py <old-apps.json> <new-apps.json> [--report report.md]
+    python3 validation/check.py <old-apps.json> <new-apps.json> [--report report.md] [--commit SHA]
 
 --report writes a markdown summary of every finding, for CI to post on the PR.
 """
@@ -97,11 +97,12 @@ def main() -> None:
     parser.add_argument("old_apps", type=Path, help="apps.json at the base revision")
     parser.add_argument("new_apps", type=Path, help="apps.json as proposed")
     parser.add_argument("--report", type=Path, help="write a markdown report of all findings here")
+    parser.add_argument("--commit", default="", help="head SHA the report describes")
     args = parser.parse_args()
 
     marketplace = load_apps(args.old_apps)
     new_apps = load_apps(args.new_apps)
-    report = Report()
+    report = Report(commit=args.commit)
 
     apps = changed_apps(marketplace, new_apps)
     if not apps:

--- a/validation/check.py
+++ b/validation/check.py
@@ -57,8 +57,9 @@ def _clone(target: dict, clone_dir: Path, section: Section) -> bool:
         return True
     except RuntimeError as exc:
         print(f"  FAIL: {exc}")
+        message = str(exc).replace(str(clone_dir), target["name"])
         section.checks.append(
-            CheckResult(name="clone", status="failed", findings=[Finding(message=str(exc))])
+            CheckResult(name="clone", status="failed", findings=[Finding(message=message)])
         )
         return False
 

--- a/validation/get_app_check.py
+++ b/validation/get_app_check.py
@@ -61,6 +61,10 @@ class GetAppValidator(Validator):
         self.target = target
         self.clone_dir = clone_dir
 
+    def fail(self, message: str, **details) -> None:
+        """Report install output against the app's own name, not the temp checkout."""
+        super().fail(message.replace(str(self.clone_dir), self.target["name"]), **details)
+
     def validate(self) -> None:
         frappe_core = self.target.get("frappe_core")
         if not frappe_core:

--- a/validation/semgrep_check.py
+++ b/validation/semgrep_check.py
@@ -64,8 +64,7 @@ class SemgrepValidator(Validator):
 
     def _describe_finding(self, finding: dict) -> dict:
         extra = finding.get("extra", {})
-        # Paths are absolute inside the throwaway clone dir; the contributor
-        # needs them relative to their own repo root.
+        # Absolute inside the throwaway clone dir; report them repo-relative.
         path = str(Path(finding["path"]).relative_to(self.clone_dir))
         return {
             "message": " ".join(extra.get("message", "").split()),

--- a/validation/semgrep_check.py
+++ b/validation/semgrep_check.py
@@ -16,18 +16,10 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).parent))
 from utils.base import Validator
+from utils.report import severity_label
 
 RULES_DIR = Path(__file__).parent / "semgrep-rules"
 
-SEMGREP_TO_AUDIT_SEVERITY = {
-    "CRITICAL": "Critical",
-    "ERROR": "Critical",
-    "HIGH": "Major",
-    "WARNING": "Minor",
-    "MEDIUM": "Minor",
-    "LOW": "Info",
-    "INFO": "Info",
-}
 BLOCKING_AUDIT_SEVERITIES = {"Critical", "Major"}
 
 
@@ -46,16 +38,12 @@ def is_blocking(finding: dict) -> bool:
     metadata = finding.get("extra", {}).get("metadata", {})
     if metadata.get("is_blocking") is True:
         return True
-    severity = str(finding.get("extra", {}).get("severity", "INFO")).upper()
-    return SEMGREP_TO_AUDIT_SEVERITY.get(severity, "Info") in BLOCKING_AUDIT_SEVERITIES
+    return severity_label(finding.get("extra", {}).get("severity", "INFO")) in BLOCKING_AUDIT_SEVERITIES
 
 
-def print_finding(finding: dict) -> None:
-    extra = finding.get("extra", {})
-    message = " ".join(extra.get("message", "").split())
-    line = finding.get("start", {}).get("line")
-    print(f"  [{extra.get('severity')}] {finding['path']}:{line} ({finding['check_id']})")
-    print(f"    {message}")
+def rule_name(check_id: str) -> str:
+    """Semgrep reports the rule's full dotted path; only the last part names it."""
+    return check_id.rsplit(".", 1)[-1]
 
 
 class SemgrepValidator(Validator):
@@ -71,7 +59,18 @@ class SemgrepValidator(Validator):
         blocking = [f for f in findings if is_blocking(f)]
         print(f"  Scanned {self.label}: {len(findings)} finding(s), {len(blocking)} blocking.")
         for finding in findings:
-            print_finding(finding)
-        for finding in blocking:
-            severity = finding.get("extra", {}).get("severity")
-            self.fail(f"[{severity}] {finding['path']} ({finding['check_id']})")
+            record = self.fail if is_blocking(finding) else self.note
+            record(**self._describe_finding(finding))
+
+    def _describe_finding(self, finding: dict) -> dict:
+        extra = finding.get("extra", {})
+        # Paths are absolute inside the throwaway clone dir; the contributor
+        # needs them relative to their own repo root.
+        path = str(Path(finding["path"]).relative_to(self.clone_dir))
+        return {
+            "message": " ".join(extra.get("message", "").split()),
+            "severity": severity_label(extra.get("severity", "INFO")),
+            "rule": rule_name(finding.get("check_id", "")),
+            "path": path,
+            "line": finding.get("start", {}).get("line"),
+        }

--- a/validation/utils/base.py
+++ b/validation/utils/base.py
@@ -4,9 +4,8 @@ Base class for marketplace app validators.
 
 Each validator collects failures via fail() while validate() runs, then
 run() reports an overall pass/fail. Subclasses take only the inputs they
-need and implement validate(). Findings are kept structured so the PR
-report can group and label them; the console output stays readable on its
-own for anyone reading the job log.
+need and implement validate(). Findings are structured so the PR report
+can group and label them.
 """
 
 from __future__ import annotations
@@ -26,13 +25,13 @@ class Validator:
         return self.findings
 
     def fail(self, message: str, **details) -> None:
-        """Record a blocking finding. `details` matches Finding's fields."""
+        """Record a blocking finding; `details` matches Finding's fields."""
         finding = Finding(message=message, **details)
         self.findings.append(finding)
         print(f"  FAIL: {self._describe(finding)}")
 
     def note(self, message: str, **details) -> None:
-        """Record a non-blocking finding — reported, but the check still passes."""
+        """Record an advisory finding; reported, but the check still passes."""
         finding = Finding(message=message, **details)
         self.notes.append(finding)
         print(f"  NOTE: {self._describe(finding)}")

--- a/validation/utils/base.py
+++ b/validation/utils/base.py
@@ -4,21 +4,44 @@ Base class for marketplace app validators.
 
 Each validator collects failures via fail() while validate() runs, then
 run() reports an overall pass/fail. Subclasses take only the inputs they
-need and implement validate().
+need and implement validate(). Findings are kept structured so the PR
+report can group and label them; the console output stays readable on its
+own for anyone reading the job log.
 """
 
 from __future__ import annotations
+
+from utils.report import Finding
 
 
 class Validator:
     name = "validation"
 
     def __init__(self) -> None:
-        self.errors: list[str] = []
+        self.findings: list[Finding] = []
+        self.notes: list[Finding] = []
 
-    def fail(self, message: str) -> None:
-        self.errors.append(message)
-        print(f"  FAIL: {message}")
+    @property
+    def errors(self) -> list[Finding]:
+        return self.findings
+
+    def fail(self, message: str, **details) -> None:
+        """Record a blocking finding. `details` matches Finding's fields."""
+        finding = Finding(message=message, **details)
+        self.findings.append(finding)
+        print(f"  FAIL: {self._describe(finding)}")
+
+    def note(self, message: str, **details) -> None:
+        """Record a non-blocking finding — reported, but the check still passes."""
+        finding = Finding(message=message, **details)
+        self.notes.append(finding)
+        print(f"  NOTE: {self._describe(finding)}")
+
+    @staticmethod
+    def _describe(finding: Finding) -> str:
+        where = f" {finding.location}" if finding.location else ""
+        rule = f" ({finding.rule})" if finding.rule else ""
+        return f"[{finding.severity}]{where} {finding.message}{rule}"
 
     def validate(self) -> None:
         raise NotImplementedError
@@ -26,8 +49,8 @@ class Validator:
     def run(self) -> bool:
         print(f"\n--- {self.name} ---", flush=True)
         self.validate()
-        if self.errors:
-            print(f"  {len(self.errors)} issue(s) found.")
+        if self.findings:
+            print(f"  {len(self.findings)} issue(s) found.")
         else:
-            print("  PASSED.")
-        return not self.errors
+            print("  PASSED." if not self.notes else f"  PASSED ({len(self.notes)} advisory).")
+        return not self.findings

--- a/validation/utils/report.py
+++ b/validation/utils/report.py
@@ -1,0 +1,202 @@
+#!/usr/bin/env python3
+"""
+Turns validator findings into a markdown report for the PR — a contributor
+reads the PR, not the raw job log, so severities are spelled out ("Critical",
+not "[ERROR]") and repeated hits of one rule are grouped under it instead of
+listed as 40 near-identical lines.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+# Semgrep's own severity words are not what a contributor should have to
+# decode; these are the audit labels the marketplace reports in.
+SEVERITY_LABELS = {
+    "CRITICAL": "Critical",
+    "ERROR": "Critical",
+    "HIGH": "Major",
+    "WARNING": "Minor",
+    "MEDIUM": "Minor",
+    "LOW": "Info",
+    "INFO": "Info",
+}
+SEVERITY_ORDER = ["Critical", "Major", "Minor", "Info"]
+SEVERITY_ICONS = {"Critical": "🔴", "Major": "🟠", "Minor": "🟡", "Info": "🔵"}
+
+COMMENT_MARKER = "<!-- marketplace-app-check -->"
+# GitHub rejects comment bodies over 65536 characters; leave room for the notice.
+MAX_REPORT_CHARS = 60000
+
+
+def severity_label(semgrep_severity: str) -> str:
+    return SEVERITY_LABELS.get(str(semgrep_severity).upper(), "Info")
+
+
+@dataclass
+class Finding:
+    """One thing wrong with an app, from any of the checks."""
+
+    message: str
+    severity: str = "Critical"
+    rule: str = ""
+    path: str = ""
+    line: int | None = None
+
+    @property
+    def location(self) -> str:
+        if not self.path:
+            return ""
+        return f"{self.path}:{self.line}" if self.line else self.path
+
+
+@dataclass
+class CheckResult:
+    name: str
+    status: str  # passed | failed | skipped
+    findings: list[Finding] = field(default_factory=list)
+    notes: list[Finding] = field(default_factory=list)  # non-blocking
+
+
+@dataclass
+class Section:
+    """One app, or one of its targets, and how each check went for it."""
+
+    title: str
+    subtitle: str = ""
+    checks: list[CheckResult] = field(default_factory=list)
+
+    @property
+    def passed(self) -> bool:
+        return all(check.status != "failed" for check in self.checks)
+
+
+STATUS_ICONS = {"passed": "✅", "failed": "❌", "skipped": "⏭️"}
+
+
+class Report:
+    def __init__(self) -> None:
+        self.sections: list[Section] = []
+
+    def section(self, title: str, subtitle: str = "") -> Section:
+        section = Section(title=title, subtitle=subtitle)
+        self.sections.append(section)
+        return section
+
+    @property
+    def passed(self) -> bool:
+        return all(section.passed for section in self.sections)
+
+    def render(self) -> str:
+        if not self.sections:
+            return f"{COMMENT_MARKER}\n## Marketplace app check\n\nNo app changes to check.\n"
+
+        lines = [COMMENT_MARKER, "## Marketplace app check", ""]
+        lines += self._render_overview()
+        for section in self.sections:
+            lines += self._render_section(section)
+        lines += [
+            "",
+            "---",
+            "<sub>Re-run these checks by pushing to the branch. See "
+            "[what CI checks](https://github.com/frappe/marketplace/blob/main/README.md#what-ci-checks) "
+            "for what each one does.</sub>",
+        ]
+        return self._cap("\n".join(lines) + "\n")
+
+    @staticmethod
+    def _cap(body: str) -> str:
+        if len(body) <= MAX_REPORT_CHARS:
+            return body
+        notice = "\n\n> Report truncated — see the job log for the full list of findings.\n"
+        return body[: MAX_REPORT_CHARS - len(notice)] + notice
+
+    def _render_overview(self) -> list[str]:
+        verdict = "All checks passed." if self.passed else "Some checks failed — details below."
+        lines = [verdict, "", "| App | Check | Result |", "| --- | --- | --- |"]
+        for section in self.sections:
+            for check in section.checks:
+                icon = STATUS_ICONS.get(check.status, "")
+                lines.append(f"| `{section.title}` | {check.name} | {icon} {self._result_text(check)} |")
+        lines.append("")
+        return lines
+
+    @staticmethod
+    def _result_text(check: CheckResult) -> str:
+        if check.status == "skipped":
+            return "skipped"
+        if check.status == "passed":
+            return "passed" if not check.notes else f"passed ({len(check.notes)} advisory)"
+        return f"{len(check.findings)} blocking issue(s)"
+
+    def _render_section(self, section: Section) -> list[str]:
+        if section.passed and not any(check.notes for check in section.checks):
+            return []
+
+        heading = f"### {section.title}"
+        lines = ["", heading]
+        if section.subtitle:
+            lines.append(f"<sub>{section.subtitle}</sub>")
+
+        for check in section.checks:
+            if check.findings:
+                lines += ["", f"#### {check.name} — {len(check.findings)} blocking"]
+                lines += self._render_rule_summary(check.findings)
+                lines += self._render_findings(check.findings)
+            if check.notes:
+                lines += ["", "<details>", f"<summary>{len(check.notes)} advisory finding(s) "
+                          f"from {check.name} — not blocking</summary>", ""]
+                lines += self._render_findings(check.notes)
+                lines += ["", "</details>"]
+        return lines
+
+    @staticmethod
+    def _render_rule_summary(findings: list[Finding]) -> list[str]:
+        """A rule-level count first, so the scale is clear before the detail."""
+        counts: dict[tuple[str, str], int] = {}
+        for finding in findings:
+            if finding.rule:
+                counts[(finding.rule, finding.severity)] = counts.get((finding.rule, finding.severity), 0) + 1
+        if not counts:
+            return []
+        rows = sorted(
+            counts.items(),
+            key=lambda item: (SEVERITY_ORDER.index(item[0][1]) if item[0][1] in SEVERITY_ORDER else 99,
+                              -item[1]),
+        )
+        lines = ["", "| Rule | Severity | Count |", "| --- | --- | --- |"]
+        for (rule, severity), count in rows:
+            lines.append(f"| `{rule}` | {SEVERITY_ICONS.get(severity, '')} {severity} | {count} |")
+        return lines
+
+    def _render_findings(self, findings: list[Finding]) -> list[str]:
+        lines: list[str] = []
+        for (rule, severity, message), group in self._group(findings):
+            header = f"{SEVERITY_ICONS.get(severity, '')} **{severity}** — {message}"
+            lines += ["", header]
+            if rule:
+                lines.append(f"<sub>rule: `{rule}`</sub>")
+            locations = [finding.location for finding in group if finding.location]
+            lines += self._render_locations(locations)
+        return lines
+
+    @staticmethod
+    def _render_locations(locations: list[str]) -> list[str]:
+        if not locations:
+            return []
+        if len(locations) <= 5:
+            return [""] + [f"- `{location}`" for location in locations]
+        listed = "\n".join(f"- `{location}`" for location in locations)
+        return ["", "<details>", f"<summary>{len(locations)} locations</summary>", "", listed, "", "</details>"]
+
+    @staticmethod
+    def _group(findings: list[Finding]):
+        """Group by (rule, severity, message), preserving worst-severity-first order."""
+        grouped: dict[tuple[str, str, str], list[Finding]] = {}
+        for finding in findings:
+            grouped.setdefault((finding.rule, finding.severity, finding.message), []).append(finding)
+        return sorted(
+            grouped.items(),
+            key=lambda item: (SEVERITY_ORDER.index(item[0][1]) if item[0][1] in SEVERITY_ORDER else 99,
+                              -len(item[1])),
+        )

--- a/validation/utils/report.py
+++ b/validation/utils/report.py
@@ -1,17 +1,10 @@
 #!/usr/bin/env python3
-"""
-Turns validator findings into a markdown report for the PR — a contributor
-reads the PR, not the raw job log, so severities are spelled out ("Critical",
-not "[ERROR]") and repeated hits of one rule are grouped under it instead of
-listed as 40 near-identical lines.
-"""
 
 from __future__ import annotations
 
 from dataclasses import dataclass, field
 
-# Semgrep's own severity words are not what a contributor should have to
-# decode; these are the audit labels the marketplace reports in.
+# Semgrep's severity words, mapped to the labels the marketplace reports in.
 SEVERITY_LABELS = {
     "CRITICAL": "Critical",
     "ERROR": "Critical",
@@ -25,8 +18,7 @@ SEVERITY_ORDER = ["Critical", "Major", "Minor", "Info"]
 SEVERITY_ICONS = {"Critical": "🔴", "Major": "🟠", "Minor": "🟡", "Info": "🔵"}
 
 COMMENT_MARKER = "<!-- marketplace-app-check -->"
-# GitHub rejects comment bodies over 65536 characters; leave room for the notice.
-MAX_REPORT_CHARS = 60000
+MAX_REPORT_CHARS = 60000  # GitHub rejects comment bodies over 65536
 
 
 def severity_label(semgrep_severity: str) -> str:
@@ -75,11 +67,11 @@ STATUS_ICONS = {"passed": "✅", "failed": "❌", "skipped": "⏭️"}
 
 
 class Report:
+    """Findings from every check, rendered as markdown for the PR."""
+
     def __init__(self, commit: str = "") -> None:
         self.sections: list[Section] = []
-        # Stamped into the report so a comment always says which commit it
-        # describes — a reader can tell at a glance if it predates the tip.
-        self.commit = commit
+        self.commit = commit  # named in the report, so a stale comment is visible
 
     def section(self, title: str, subtitle: str = "") -> Section:
         section = Section(title=title, subtitle=subtitle)
@@ -164,7 +156,7 @@ class Report:
 
     @staticmethod
     def _render_rule_summary(findings: list[Finding]) -> list[str]:
-        """A rule-level count first, so the scale is clear before the detail."""
+        """Rule-level counts, so the scale is clear before the detail."""
         counts: dict[tuple[str, str], int] = {}
         for finding in findings:
             if finding.rule:

--- a/validation/utils/report.py
+++ b/validation/utils/report.py
@@ -17,7 +17,7 @@ SEVERITY_LABELS = {
 SEVERITY_ORDER = ["Critical", "Major", "Minor", "Info"]
 SEVERITY_ICONS = {"Critical": "🔴", "Major": "🟠", "Minor": "🟡", "Info": "🔵"}
 
-COMMENT_MARKER = "<!-- marketplace-app-check -->"
+COMMENT_MARKER = "<!-- marketplace-app-check"  # CI greps this to find its own comment
 MAX_REPORT_CHARS = 60000  # GitHub rejects comment bodies over 65536
 MESSAGE_INLINE_CHARS = 200  # longer than this reads better as a block
 
@@ -84,17 +84,22 @@ class Report:
         return all(section.passed for section in self.sections)
 
     @property
+    def _marker(self) -> str:
+        """Names the commit, so CI can refuse to overwrite a newer report."""
+        return f"{COMMENT_MARKER} {self.commit} -->" if self.commit else f"{COMMENT_MARKER} -->"
+
+    @property
     def _commit_line(self) -> str:
         return f"<sub>Checked commit `{self.commit[:7]}`.</sub>\n" if self.commit else ""
 
     def render(self) -> str:
         if not self.sections:
             return (
-                f"{COMMENT_MARKER}\n## Marketplace app check\n\n"
+                f"{self._marker}\n## Marketplace app check\n\n"
                 f"No app changes to check.\n{self._commit_line}"
             )
 
-        lines = [COMMENT_MARKER, "## Marketplace app check", ""]
+        lines = [self._marker, "## Marketplace app check", ""]
         if self.commit:
             lines += [self._commit_line.rstrip("\n"), ""]
         lines += self._render_overview()

--- a/validation/utils/report.py
+++ b/validation/utils/report.py
@@ -75,8 +75,11 @@ STATUS_ICONS = {"passed": "✅", "failed": "❌", "skipped": "⏭️"}
 
 
 class Report:
-    def __init__(self) -> None:
+    def __init__(self, commit: str = "") -> None:
         self.sections: list[Section] = []
+        # Stamped into the report so a comment always says which commit it
+        # describes — a reader can tell at a glance if it predates the tip.
+        self.commit = commit
 
     def section(self, title: str, subtitle: str = "") -> Section:
         section = Section(title=title, subtitle=subtitle)
@@ -87,11 +90,20 @@ class Report:
     def passed(self) -> bool:
         return all(section.passed for section in self.sections)
 
+    @property
+    def _commit_line(self) -> str:
+        return f"<sub>Checked commit `{self.commit[:7]}`.</sub>\n" if self.commit else ""
+
     def render(self) -> str:
         if not self.sections:
-            return f"{COMMENT_MARKER}\n## Marketplace app check\n\nNo app changes to check.\n"
+            return (
+                f"{COMMENT_MARKER}\n## Marketplace app check\n\n"
+                f"No app changes to check.\n{self._commit_line}"
+            )
 
         lines = [COMMENT_MARKER, "## Marketplace app check", ""]
+        if self.commit:
+            lines += [self._commit_line.rstrip("\n"), ""]
         lines += self._render_overview()
         for section in self.sections:
             lines += self._render_section(section)

--- a/validation/utils/report.py
+++ b/validation/utils/report.py
@@ -19,6 +19,7 @@ SEVERITY_ICONS = {"Critical": "🔴", "Major": "🟠", "Minor": "🟡", "Info": 
 
 COMMENT_MARKER = "<!-- marketplace-app-check -->"
 MAX_REPORT_CHARS = 60000  # GitHub rejects comment bodies over 65536
+MESSAGE_INLINE_CHARS = 200  # longer than this reads better as a block
 
 
 def severity_label(semgrep_severity: str) -> str:
@@ -176,8 +177,13 @@ class Report:
     def _render_findings(self, findings: list[Finding]) -> list[str]:
         lines: list[str] = []
         for (rule, severity, message), group in self._group(findings):
-            header = f"{SEVERITY_ICONS.get(severity, '')} **{severity}** — {message}"
-            lines += ["", header]
+            icon = SEVERITY_ICONS.get(severity, "")
+            # Tool output (a failed clone, a failed install) runs to several
+            # lines and would break the markdown if inlined in the heading.
+            if "\n" in message or len(message) > MESSAGE_INLINE_CHARS:
+                lines += ["", f"{icon} **{severity}**", "", "```", message.strip(), "```"]
+            else:
+                lines += ["", f"{icon} **{severity}** — {message}"]
             if rule:
                 lines.append(f"<sub>rule: `{rule}`</sub>")
             locations = [finding.location for finding in group if finding.location]


### PR DESCRIPTION
Today a contributor whose app fails the checks has to open the workflow run and read output like this:

```
FAIL: [ERROR] /tmp/tmpn2454l2x/app/suite/drive/api/list.py (validation.semgrep-rules.marketplace-security.frappe-breaks-multitenancy)
FAIL: [ERROR] /tmp/tmpn2454l2x/app/suite/drive/api/list.py (validation.semgrep-rules.marketplace-security.frappe-breaks-multitenancy)
... 46 more
48 issue(s) found.
```

Raw semgrep severity tags, temp-dir paths, no line numbers, one line per hit, nothing on the PR itself.

## What this does

Validators now collect structured findings (severity, rule, file, line) rather than pre-formatted strings, and `check.py --report` renders them as markdown. CI posts that as a **sticky PR comment** (edited in place on each push) and writes it to the **run summary**.

The report gives a result table per app, a count table per rule, then findings grouped by rule with their locations. Severities use the `Critical`/`Major`/`Minor`/`Info` labels the marketplace already reports in — `Critical`/`Major` block, the rest are advisory and sit in a collapsed section instead of being mixed in with what actually blocks the merge. Paths are relative to the app's repo root, not the throwaway clone dir, and now carry line numbers.

Sample of the generated report for `suite@develop` (the real output from #6's findings):

---

| App | Check | Result |
| --- | --- | --- |
| `suite` | schema | ✅ passed |
| `suite@develop` | semgrep scan | ❌ 48 blocking issue(s) |
| `suite@develop` | get-app validator | ⏭️ skipped |

| Rule | Severity | Count |
| --- | --- | --- |
| `frappe-breaks-multitenancy` | 🔴 Critical | 18 |
| `frappe-ssti` | 🔴 Critical | 4 |
| `frappe-cache-breaks-multitenancy` | 🔴 Critical | 3 |
| `frappe-manual-commit` | 🟠 Major | 15 |
| `frappe-realtime-pick-room` | 🟠 Major | 6 |
| `frappe-sql-format-injection` | 🟠 Major | 2 |

🔴 **Critical** — redis.set and redis.get do not support multitenancy, use set_value/get_value instead.
<sub>rule: `frappe-cache-breaks-multitenancy`</sub>

- `suite/drive/locks/distributed_lock.py:48`
- `suite/utils/lock.py:34`
- `suite/utils/lock.py:42`

---

## Notes

- **Fork PRs** get a read-only token, so the comment can't be posted there. That step is best-effort (`|| echo`) and the run summary carries the same report — it can't affect the job's pass/fail either way.
- Report bodies are capped at 60k chars, under GitHub's 65536 comment limit, with a pointer to the job log if truncated.
- Blocking behaviour is unchanged: verified locally against `frappe/suite@develop`, same 48 blocking findings and same exit code as the current run on #6.
- This PR doesn't touch `apps.json`, so the diff gate skips the checks here — same caveat as #7. Updating #6 after this merges is what exercises it for real.

🤖 Generated with [Claude Code](https://claude.com/claude-code)