### PR TITLE
ci: add a /refresh command to re-run the app checks

### DIFF
--- a/.github/scripts/refresh_command.sh
+++ b/.github/scripts/refresh_command.sh
@@ -41,16 +41,24 @@ case "$ASSOCIATION" in
 esac
 
 react eyes
-# Scoped to this PR: a commit can be the head of more than one PR, so match
-# the branch too, and prefer a run GitHub already associates with this PR.
+# A commit can head more than one PR, so match the branch too, take the run
+# GitHub attributes to this PR, and never touch one attributed to another.
 runs=$(gh api "repos/$GITHUB_REPOSITORY/actions/workflows/$WORKFLOW/runs?event=pull_request&head_sha=$head_sha&branch=$head_branch&per_page=20" \
   --jq .workflow_runs)
-run=$(jq -c --argjson pr "$PR" '
-  (map(select(.pull_requests | map(.number) | index($pr))) | first)
-  // first // empty' <<<"$runs")
+mine=$(jq -c --argjson pr "$PR" '[.[] | select(.pull_requests | map(.number) | index($pr))]' <<<"$runs")
+run=$(jq -c 'first // empty' <<<"$mine")
 
-if [ -z "$run" ] || [ "$run" = "null" ]; then
-  say "No app check run found for \`${head_sha:0:7}\` to refresh — push a commit to start one."
+if [ -z "$run" ]; then
+  # Forks come back with no PR attribution at all, so a single candidate is
+  # this PR's by elimination; several are indistinguishable and left alone.
+  unattributed=$(jq -c '[.[] | select(.pull_requests | length == 0)]' <<<"$runs")
+  if [ "$(jq length <<<"$unattributed")" = "1" ]; then
+    run=$(jq -c '.[0]' <<<"$unattributed")
+  fi
+fi
+
+if [ -z "$run" ]; then
+  say "No app check run for \`${head_sha:0:7}\` could be matched to this PR — push a commit to start a fresh one."
   exit 0
 fi
 

--- a/.github/scripts/refresh_command.sh
+++ b/.github/scripts/refresh_command.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # Re-run the app check for a PR, in response to a /refresh comment.
 # Usage: refresh_command.sh
-# Env:   PR, COMMENT_ID, ASSOCIATION, COMMENTER, GITHUB_REPOSITORY, GITHUB_TOKEN
+# Env:   PR, COMMENT_ID, ASSOCIATION, COMMENTER, BODY, GITHUB_REPOSITORY, GITHUB_TOKEN
 
 set -euo pipefail
 
@@ -16,8 +16,16 @@ say() {
   gh pr comment "$PR" --body "$1" >/dev/null 2>&1 || echo "$1"
 }
 
-pr=$(gh pr view "$PR" --json headRefOid,author)
+# Exact match only: "/refresher" and "/refresh rm -rf" are not this command.
+command=$(printf '%s' "$BODY" | tr -d '\r' | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')
+if [ "$command" != "/refresh" ]; then
+  echo "Not a /refresh command; ignoring."
+  exit 0
+fi
+
+pr=$(gh pr view "$PR" --json headRefOid,headRefName,author)
 head_sha=$(jq -r .headRefOid <<<"$pr")
+head_branch=$(jq -r .headRefName <<<"$pr")
 
 # A re-run spends CI on code the commenter may not own; the PR's own author
 # qualifies, since pushing a commit would rerun the checks anyway.
@@ -33,8 +41,13 @@ case "$ASSOCIATION" in
 esac
 
 react eyes
-run=$(gh run list --workflow "$WORKFLOW" --json databaseId,headSha,status --limit 50 \
-  --jq "[.[] | select(.headSha == \"$head_sha\")] | first")
+# Scoped to this PR: a commit can be the head of more than one PR, so match
+# the branch too, and prefer a run GitHub already associates with this PR.
+runs=$(gh api "repos/$GITHUB_REPOSITORY/actions/workflows/$WORKFLOW/runs?event=pull_request&head_sha=$head_sha&branch=$head_branch&per_page=20" \
+  --jq .workflow_runs)
+run=$(jq -c --argjson pr "$PR" '
+  (map(select(.pull_requests | map(.number) | index($pr))) | first)
+  // first // empty' <<<"$runs")
 
 if [ -z "$run" ] || [ "$run" = "null" ]; then
   say "No app check run found for \`${head_sha:0:7}\` to refresh — push a commit to start one."
@@ -46,6 +59,6 @@ if [ "$(jq -r .status <<<"$run")" != "completed" ]; then
   exit 0
 fi
 
-gh run rerun "$(jq -r .databaseId <<<"$run")"
+gh run rerun "$(jq -r .id <<<"$run")"
 react rocket
 echo "Re-ran the app check for $head_sha."

--- a/.github/scripts/refresh_command.sh
+++ b/.github/scripts/refresh_command.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# Re-run the app check for a PR, in response to a /refresh comment.
+# Usage: refresh_command.sh
+# Env:   PR, COMMENT_ID, ASSOCIATION, COMMENTER, GITHUB_REPOSITORY, GITHUB_TOKEN
+
+set -euo pipefail
+
+WORKFLOW=marketplace-app-check.yml
+
+react() {
+  gh api "repos/$GITHUB_REPOSITORY/issues/comments/$COMMENT_ID/reactions" \
+    -f content="$1" --silent 2>/dev/null || true
+}
+
+say() {
+  gh pr comment "$PR" --body "$1" >/dev/null 2>&1 || echo "$1"
+}
+
+pr=$(gh pr view "$PR" --json headRefOid,author)
+head_sha=$(jq -r .headRefOid <<<"$pr")
+
+# A re-run spends CI on code the commenter may not own; the PR's own author
+# qualifies, since pushing a commit would rerun the checks anyway.
+case "$ASSOCIATION" in
+  OWNER | MEMBER | COLLABORATOR) ;;
+  *)
+    if [ "$(jq -r .author.login <<<"$pr")" != "$COMMENTER" ]; then
+      echo "Ignoring /refresh from $COMMENTER ($ASSOCIATION)."
+      react confused
+      exit 0
+    fi
+    ;;
+esac
+
+react eyes
+run=$(gh run list --workflow "$WORKFLOW" --json databaseId,headSha,status --limit 50 \
+  --jq "[.[] | select(.headSha == \"$head_sha\")] | first")
+
+if [ -z "$run" ] || [ "$run" = "null" ]; then
+  say "No app check run found for \`${head_sha:0:7}\` to refresh — push a commit to start one."
+  exit 0
+fi
+
+if [ "$(jq -r .status <<<"$run")" != "completed" ]; then
+  say "An app check for \`${head_sha:0:7}\` is already running."
+  exit 0
+fi
+
+gh run rerun "$(jq -r .databaseId <<<"$run")"
+react rocket
+echo "Re-ran the app check for $head_sha."

--- a/.github/scripts/refresh_command.sh
+++ b/.github/scripts/refresh_command.sh
@@ -49,10 +49,13 @@ mine=$(jq -c --argjson pr "$PR" '[.[] | select(.pull_requests | map(.number) | i
 run=$(jq -c 'first // empty' <<<"$mine")
 
 if [ -z "$run" ]; then
-  # Forks come back with no PR attribution at all, so a single candidate is
-  # this PR's by elimination; several are indistinguishable and left alone.
+  # Forks arrive with no PR attribution, so bind from the PR side instead: if
+  # this commit belongs to no other pull request, a run on it cannot be
+  # another PR's. Counting unattributed runs would not establish that.
+  others=$(gh api "repos/$GITHUB_REPOSITORY/commits/$head_sha/pulls" \
+    --jq "[.[] | select(.number != $PR)] | length" 2>/dev/null || echo unknown)
   unattributed=$(jq -c '[.[] | select(.pull_requests | length == 0)]' <<<"$runs")
-  if [ "$(jq length <<<"$unattributed")" = "1" ]; then
+  if [ "$others" = "0" ] && [ "$(jq length <<<"$unattributed")" = "1" ]; then
     run=$(jq -c '.[0]' <<<"$unattributed")
   fi
 fi

--- a/.github/workflows/refresh-command.yml
+++ b/.github/workflows/refresh-command.yml
@@ -1,0 +1,27 @@
+name: Refresh Command
+
+on:
+  issue_comment:
+    types: [created]
+
+# No app code runs here — it only re-runs the pull_request check, which keeps
+# its own fork-appropriate token.
+permissions:
+  actions: write
+  pull-requests: write
+
+jobs:
+  refresh:
+    if: github.event.issue.pull_request && startsWith(github.event.comment.body, '/refresh')
+    runs-on: ubuntu-22.04
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - run: .github/scripts/refresh_command.sh
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR: ${{ github.event.issue.number }}
+          COMMENT_ID: ${{ github.event.comment.id }}
+          ASSOCIATION: ${{ github.event.comment.author_association }}
+          COMMENTER: ${{ github.event.comment.user.login }}

--- a/.github/workflows/refresh-command.yml
+++ b/.github/workflows/refresh-command.yml
@@ -25,3 +25,6 @@ jobs:
           COMMENT_ID: ${{ github.event.comment.id }}
           ASSOCIATION: ${{ github.event.comment.author_association }}
           COMMENTER: ${{ github.event.comment.user.login }}
+          # Via env, never interpolated into the shell: comment bodies are
+          # attacker-controlled. The script requires an exact match.
+          BODY: ${{ github.event.comment.body }}

--- a/.github/workflows/refresh-command.yml
+++ b/.github/workflows/refresh-command.yml
@@ -12,7 +12,8 @@ permissions:
 
 jobs:
   refresh:
-    if: github.event.issue.pull_request && startsWith(github.event.comment.body, '/refresh')
+    # Exact, so a '/refresher' comment never provisions a runner.
+    if: github.event.issue.pull_request && github.event.comment.body == '/refresh'
     runs-on: ubuntu-22.04
 
     steps:

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ the run summary carries the same report.
 
 ### Re-running the checks
 
-Fixed something in your app's repo? Comment `/refresh` on the PR and the
-checks re-run against your repo's current code — no new commit needed here,
-since `apps.json` hasn't changed. The PR author and anyone with write access
-can use it.
+Fixed something in your app's repo? Comment `/refresh` — on its own, as the
+whole comment — and the checks re-run against your repo's current code. No new
+commit is needed here, since `apps.json` hasn't changed. The PR author and
+anyone with write access can use it.

--- a/README.md
+++ b/README.md
@@ -112,3 +112,10 @@ collapsed "advisory findings" section.
 
 PRs from forks get a read-only token, so the comment can't be posted there —
 the run summary carries the same report.
+
+### Re-running the checks
+
+Fixed something in your app's repo? Comment `/refresh` on the PR and the
+checks re-run against your repo's current code — no new commit needed here,
+since `apps.json` hasn't changed. The PR author and anyone with write access
+can use it.


### PR DESCRIPTION
An app author who fixes a finding in their own repo has nothing to push here — `apps.json` is unchanged — so today the checks can only be re-run by someone with repo access. Commenting `/refresh` on the PR now re-runs them against the app repo's current code.

**Who can use it:** the PR author, plus anyone with write access. A fork PR author is `CONTRIBUTOR` or `NONE`, so association alone would have locked out exactly the person the command is for; the PR's own author is matched by login instead. Everyone else gets a 👀-free `confused` reaction and nothing runs.

**Why it re-runs rather than scans:** `issue_comment` gets a write-capable token, and the checks `uv pip install` the app under review — third-party code with build hooks. Re-running the existing `pull_request` run keeps that code under its own fork-appropriate token; this job only calls the API.

Reactions mark progress: 👀 accepted, 🚀 re-run started, 😕 ignored. If a run is already in flight, or none exists for the head commit, it says so instead of starting one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)