### PR TITLE
ci: stamp the report with its run, and clear the eyes reaction

### DIFF
--- a/.github/scripts/refresh_command.sh
+++ b/.github/scripts/refresh_command.sh
@@ -9,7 +9,13 @@ WORKFLOW=marketplace-app-check.yml
 
 react() {
   gh api "repos/$GITHUB_REPOSITORY/issues/comments/$COMMENT_ID/reactions" \
-    -f content="$1" --silent 2>/dev/null || true
+    -f content="$1" --jq .id 2>/dev/null || true
+}
+
+unreact() {
+  [ -n "$1" ] || return 0
+  gh api -X DELETE "repos/$GITHUB_REPOSITORY/issues/comments/$COMMENT_ID/reactions/$1" \
+    --silent 2>/dev/null || true
 }
 
 say() {
@@ -34,13 +40,13 @@ case "$ASSOCIATION" in
   *)
     if [ "$(jq -r .author.login <<<"$pr")" != "$COMMENTER" ]; then
       echo "Ignoring /refresh from $COMMENTER ($ASSOCIATION)."
-      react confused
+      react confused >/dev/null
       exit 0
     fi
     ;;
 esac
 
-react eyes
+eyes_id=$(react eyes)
 # A commit can head more than one PR, so match the branch too, take the run
 # GitHub attributes to this PR, and never touch one attributed to another.
 runs=$(gh api "repos/$GITHUB_REPOSITORY/actions/workflows/$WORKFLOW/runs?event=pull_request&head_sha=$head_sha&branch=$head_branch&per_page=20" \
@@ -71,5 +77,6 @@ if [ "$(jq -r .status <<<"$run")" != "completed" ]; then
 fi
 
 gh run rerun "$(jq -r .id <<<"$run")"
-react rocket
+react rocket >/dev/null
+unreact "$eyes_id"
 echo "Re-ran the app check for $head_sha."

--- a/.github/workflows/marketplace-app-check.yml
+++ b/.github/workflows/marketplace-app-check.yml
@@ -81,7 +81,8 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           python3 validation/check.py /tmp/apps_before.json apps.json \
-            --report /tmp/report.md --commit "${{ github.event.pull_request.head.sha }}"
+            --report /tmp/report.md --commit "${{ github.event.pull_request.head.sha }}" \
+            --run-url "$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"
 
       # !cancelled(), not always(): failures must report, but a superseded
       # run must stay quiet — always() is true for cancelled runs too.

--- a/README.md
+++ b/README.md
@@ -102,7 +102,8 @@ runs two checks, in order:
 ### Reading the results
 
 CI posts a report as a comment on your PR — one comment, edited in place on
-each push — and repeats it in the workflow run's summary. It lists every
+each push, stamped with when it last ran — and repeats it in the workflow
+run's summary. It lists every
 finding grouped by rule, with severity and `file:line` locations, so you
 shouldn't need to open the raw job log.
 

--- a/validation/check.py
+++ b/validation/check.py
@@ -7,7 +7,8 @@ at the first failure. A schema-failed app's targets are skipped entirely.
 Exits non-zero if anything fails.
 
 Run:
-    python3 validation/check.py <old-apps.json> <new-apps.json> [--report report.md] [--commit SHA]
+    python3 validation/check.py <old-apps.json> <new-apps.json> [--report report.md]
+        [--commit SHA] [--run-url URL]
 
 --report writes a markdown summary of every finding, for CI to post on the PR.
 """
@@ -99,11 +100,12 @@ def main() -> None:
     parser.add_argument("new_apps", type=Path, help="apps.json as proposed")
     parser.add_argument("--report", type=Path, help="write a markdown report of all findings here")
     parser.add_argument("--commit", default="", help="head SHA the report describes")
+    parser.add_argument("--run-url", default="", help="link back to the workflow run")
     args = parser.parse_args()
 
     marketplace = load_apps(args.old_apps)
     new_apps = load_apps(args.new_apps)
-    report = Report(commit=args.commit)
+    report = Report(commit=args.commit, run_url=args.run_url)
 
     apps = changed_apps(marketplace, new_apps)
     if not apps:

--- a/validation/utils/report.py
+++ b/validation/utils/report.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+from datetime import datetime, timezone
 
 # Semgrep's severity words, mapped to the labels the marketplace reports in.
 SEVERITY_LABELS = {
@@ -70,9 +71,10 @@ STATUS_ICONS = {"passed": "✅", "failed": "❌", "skipped": "⏭️"}
 class Report:
     """Findings from every check, rendered as markdown for the PR."""
 
-    def __init__(self, commit: str = "") -> None:
+    def __init__(self, commit: str = "", run_url: str = "") -> None:
         self.sections: list[Section] = []
         self.commit = commit  # named in the report, so a stale comment is visible
+        self.run_url = run_url
 
     def section(self, title: str, subtitle: str = "") -> Section:
         section = Section(title=title, subtitle=subtitle)
@@ -87,6 +89,19 @@ class Report:
     def _marker(self) -> str:
         """Names the commit, so CI can refuse to overwrite a newer report."""
         return f"{COMMENT_MARKER} {self.commit} -->" if self.commit else f"{COMMENT_MARKER} -->"
+
+    @property
+    def _footer(self) -> str:
+        """Stamped with the time so a re-run that finds the same issues still
+        visibly happened."""
+        stamp = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M UTC")
+        run = f" · [run log]({self.run_url})" if self.run_url else ""
+        return (
+            f"<sub>Updated {stamp}{run} — fixed something in your app? Comment `/refresh` "
+            "to run these checks again. See "
+            "[what CI checks](https://github.com/frappe/marketplace/blob/main/README.md#what-ci-checks)"
+            ".</sub>"
+        )
 
     @property
     def _commit_line(self) -> str:
@@ -105,13 +120,7 @@ class Report:
         lines += self._render_overview()
         for section in self.sections:
             lines += self._render_section(section)
-        lines += [
-            "",
-            "---",
-            "<sub>Re-run these checks by pushing to the branch. See "
-            "[what CI checks](https://github.com/frappe/marketplace/blob/main/README.md#what-ci-checks) "
-            "for what each one does.</sub>",
-        ]
+        lines += ["", "---", self._footer]
         return self._cap("\n".join(lines) + "\n")
 
     @staticmethod


### PR DESCRIPTION
Two things surfaced by running `/refresh` on #6:

**The report gave no sign it had re-run.** The comment was rewritten (`updated_at` moved from 09:47:49 to 10:22:10) but the body was byte-identical, since suite's findings hadn't changed — so the PR looked untouched apart from GitHub's small "edited" marker. The footer now carries the time it last ran and a link to the run:

> <sub>Updated 2026-07-29 10:25 UTC · [run log](https://github.com/frappe/marketplace/actions/runs/30441049195) — fixed something in your app? Comment `/refresh` to run these checks again.</sub>

It also now points at `/refresh`, which the old wording predated — it only mentioned pushing a commit.

**The command comment kept both reactions.** 👀 stayed alongside 🚀. The eyes reaction is now removed once the re-run starts, so the comment ends up with just 🚀 — or 😕 alone if the command was refused.

🤖 Generated with [Claude Code](https://claude.com/claude-code)