### PR TITLE
ci: rename the command to /rereview

### DIFF
--- a/.github/scripts/rereview_command.sh
+++ b/.github/scripts/rereview_command.sh
@@ -7,7 +7,6 @@ set -euo pipefail
 
 WORKFLOW=marketplace-app-check.yml
 MARKER='<!-- marketplace-app-check'
-RUNNING_NOTE="> 🔄 Re-review requested — the checks are running again."
 
 react() {
   gh api "repos/$GITHUB_REPOSITORY/issues/comments/$COMMENT_ID/reactions" \
@@ -21,19 +20,6 @@ say() {
 report_comment_id() {
   gh api "repos/$GITHUB_REPOSITORY/issues/$PR/comments" --paginate \
     --jq ".[] | select(.body | startswith(\"$MARKER\")) | .id" 2>/dev/null | tail -1
-}
-
-# Mark the report as re-running, so the PR shows the command was taken up.
-# The fresh report replaces the whole body and clears this.
-mark_running() {
-  local id=$1 body
-  body=$(gh api "repos/$GITHUB_REPOSITORY/issues/comments/$id" --jq .body)
-  case "$body" in *"$RUNNING_NOTE"*) return 0 ;; esac
-  printf '%s\n' "$body" |
-    awk -v note="$RUNNING_NOTE" 'NR==1 {print; print ""; print note; print ""; next} {print}' |
-    jq -Rs '{body: .}' > /tmp/running.json
-  gh api -X PATCH "repos/$GITHUB_REPOSITORY/issues/comments/$id" \
-    --input /tmp/running.json --silent 2>/dev/null || true
 }
 
 # Exact match only: "/rereviewed" and "/rereview rm -rf" are not this command.
@@ -93,12 +79,14 @@ if [ -z "$run" ]; then
   exit 0
 fi
 
+# A repeat command while the checks are still going would queue a duplicate
+# run over the one already producing the answer.
 if [ "$(jq -r .status <<<"$run")" != "completed" ]; then
-  say "An app check for \`${head_sha:0:7}\` is already running."
+  echo "An app check for $head_sha is already running; ignoring."
+  react confused
   exit 0
 fi
 
 gh run rerun "$(jq -r .id <<<"$run")"
 react rocket
-mark_running "$report_id"
 echo "Re-ran the app check for $head_sha."

--- a/.github/scripts/rereview_command.sh
+++ b/.github/scripts/rereview_command.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
-# Re-run the app check for a PR, in response to a /refresh comment.
-# Usage: refresh_command.sh
+# Re-run the app check for a PR, in response to a /rereview comment.
+# Usage: rereview_command.sh
 # Env:   PR, COMMENT_ID, ASSOCIATION, COMMENTER, BODY, GITHUB_REPOSITORY, GITHUB_TOKEN
 
 set -euo pipefail
@@ -9,23 +9,17 @@ WORKFLOW=marketplace-app-check.yml
 
 react() {
   gh api "repos/$GITHUB_REPOSITORY/issues/comments/$COMMENT_ID/reactions" \
-    -f content="$1" --jq .id 2>/dev/null || true
-}
-
-unreact() {
-  [ -n "$1" ] || return 0
-  gh api -X DELETE "repos/$GITHUB_REPOSITORY/issues/comments/$COMMENT_ID/reactions/$1" \
-    --silent 2>/dev/null || true
+    -f content="$1" --silent 2>/dev/null || true
 }
 
 say() {
   gh pr comment "$PR" --body "$1" >/dev/null 2>&1 || echo "$1"
 }
 
-# Exact match only: "/refresher" and "/refresh rm -rf" are not this command.
+# Exact match only: "/rereviewed" and "/rereview rm -rf" are not this command.
 command=$(printf '%s' "$BODY" | tr -d '\r' | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')
-if [ "$command" != "/refresh" ]; then
-  echo "Not a /refresh command; ignoring."
+if [ "$command" != "/rereview" ]; then
+  echo "Not a /rereview command; ignoring."
   exit 0
 fi
 
@@ -39,14 +33,13 @@ case "$ASSOCIATION" in
   OWNER | MEMBER | COLLABORATOR) ;;
   *)
     if [ "$(jq -r .author.login <<<"$pr")" != "$COMMENTER" ]; then
-      echo "Ignoring /refresh from $COMMENTER ($ASSOCIATION)."
-      react confused >/dev/null
+      echo "Ignoring /rereview from $COMMENTER ($ASSOCIATION)."
+      react confused
       exit 0
     fi
     ;;
 esac
 
-eyes_id=$(react eyes)
 # A commit can head more than one PR, so match the branch too, take the run
 # GitHub attributes to this PR, and never touch one attributed to another.
 runs=$(gh api "repos/$GITHUB_REPOSITORY/actions/workflows/$WORKFLOW/runs?event=pull_request&head_sha=$head_sha&branch=$head_branch&per_page=20" \
@@ -77,6 +70,5 @@ if [ "$(jq -r .status <<<"$run")" != "completed" ]; then
 fi
 
 gh run rerun "$(jq -r .id <<<"$run")"
-react rocket >/dev/null
-unreact "$eyes_id"
+react rocket
 echo "Re-ran the app check for $head_sha."

--- a/.github/scripts/rereview_command.sh
+++ b/.github/scripts/rereview_command.sh
@@ -6,6 +6,7 @@
 set -euo pipefail
 
 WORKFLOW=marketplace-app-check.yml
+MARKER='<!-- marketplace-app-check'
 RUNNING_NOTE="> 🔄 Re-review requested — the checks are running again."
 
 react() {
@@ -17,14 +18,15 @@ say() {
   gh pr comment "$PR" --body "$1" >/dev/null 2>&1 || echo "$1"
 }
 
-# Mark the existing report as re-running, so the PR shows the command was
-# taken up. The fresh report replaces the whole body and clears this.
+report_comment_id() {
+  gh api "repos/$GITHUB_REPOSITORY/issues/$PR/comments" --paginate \
+    --jq ".[] | select(.body | startswith(\"$MARKER\")) | .id" 2>/dev/null | tail -1
+}
+
+# Mark the report as re-running, so the PR shows the command was taken up.
+# The fresh report replaces the whole body and clears this.
 mark_running() {
-  local marker='<!-- marketplace-app-check'
-  local id body
-  id=$(gh api "repos/$GITHUB_REPOSITORY/issues/$PR/comments" --paginate \
-    --jq ".[] | select(.body | startswith(\"$marker\")) | .id" 2>/dev/null | tail -1)
-  [ -n "$id" ] || return 0
+  local id=$1 body
   body=$(gh api "repos/$GITHUB_REPOSITORY/issues/comments/$id" --jq .body)
   case "$body" in *"$RUNNING_NOTE"*) return 0 ;; esac
   printf '%s\n' "$body" |
@@ -58,6 +60,15 @@ case "$ASSOCIATION" in
     ;;
 esac
 
+# Only re-run once a report exists: without one there is nothing to refresh,
+# and the first run is either still going or never started.
+report_id=$(report_comment_id)
+if [ -z "$report_id" ]; then
+  say "No review has been published for this PR yet — wait for the first run to report."
+  react confused
+  exit 0
+fi
+
 # A commit can head more than one PR, so match the branch too, take the run
 # GitHub attributes to this PR, and never touch one attributed to another.
 runs=$(gh api "repos/$GITHUB_REPOSITORY/actions/workflows/$WORKFLOW/runs?event=pull_request&head_sha=$head_sha&branch=$head_branch&per_page=20" \
@@ -89,5 +100,5 @@ fi
 
 gh run rerun "$(jq -r .id <<<"$run")"
 react rocket
-mark_running
+mark_running "$report_id"
 echo "Re-ran the app check for $head_sha."

--- a/.github/scripts/rereview_command.sh
+++ b/.github/scripts/rereview_command.sh
@@ -6,6 +6,7 @@
 set -euo pipefail
 
 WORKFLOW=marketplace-app-check.yml
+RUNNING_NOTE="> 🔄 Re-review requested — the checks are running again."
 
 react() {
   gh api "repos/$GITHUB_REPOSITORY/issues/comments/$COMMENT_ID/reactions" \
@@ -14,6 +15,23 @@ react() {
 
 say() {
   gh pr comment "$PR" --body "$1" >/dev/null 2>&1 || echo "$1"
+}
+
+# Mark the existing report as re-running, so the PR shows the command was
+# taken up. The fresh report replaces the whole body and clears this.
+mark_running() {
+  local marker='<!-- marketplace-app-check'
+  local id body
+  id=$(gh api "repos/$GITHUB_REPOSITORY/issues/$PR/comments" --paginate \
+    --jq ".[] | select(.body | startswith(\"$marker\")) | .id" 2>/dev/null | tail -1)
+  [ -n "$id" ] || return 0
+  body=$(gh api "repos/$GITHUB_REPOSITORY/issues/comments/$id" --jq .body)
+  case "$body" in *"$RUNNING_NOTE"*) return 0 ;; esac
+  printf '%s\n' "$body" |
+    awk -v note="$RUNNING_NOTE" 'NR==1 {print; print ""; print note; print ""; next} {print}' |
+    jq -Rs '{body: .}' > /tmp/running.json
+  gh api -X PATCH "repos/$GITHUB_REPOSITORY/issues/comments/$id" \
+    --input /tmp/running.json --silent 2>/dev/null || true
 }
 
 # Exact match only: "/rereviewed" and "/rereview rm -rf" are not this command.
@@ -71,4 +89,5 @@ fi
 
 gh run rerun "$(jq -r .id <<<"$run")"
 react rocket
+mark_running
 echo "Re-ran the app check for $head_sha."

--- a/.github/workflows/rereview-command.yml
+++ b/.github/workflows/rereview-command.yml
@@ -1,4 +1,4 @@
-name: Refresh Command
+name: Rereview Command
 
 on:
   issue_comment:
@@ -11,15 +11,15 @@ permissions:
   pull-requests: write
 
 jobs:
-  refresh:
-    # Exact, so a '/refresher' comment never provisions a runner.
-    if: github.event.issue.pull_request && github.event.comment.body == '/refresh'
+  rereview:
+    # Exact, so a '/rereviewed' comment never provisions a runner.
+    if: github.event.issue.pull_request && github.event.comment.body == '/rereview'
     runs-on: ubuntu-22.04
 
     steps:
       - uses: actions/checkout@v4
 
-      - run: .github/scripts/refresh_command.sh
+      - run: .github/scripts/rereview_command.sh
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR: ${{ github.event.issue.number }}

--- a/README.md
+++ b/README.md
@@ -121,6 +121,6 @@ whole comment — and the checks re-run against your repo's current code. No new
 commit is needed here, since `apps.json` hasn't changed. The PR author and
 anyone with write access can use it.
 
-The comment gets a 🚀 and the report says it is re-running, until the new
-results replace it. It only works once the first report has been posted —
-before that there is nothing to re-run, so wait for the initial check.
+The comment gets a 🚀 once the checks restart. It only works after the first
+report has been posted, and a second `/rereview` while a run is still going
+is ignored.

--- a/README.md
+++ b/README.md
@@ -122,4 +122,5 @@ commit is needed here, since `apps.json` hasn't changed. The PR author and
 anyone with write access can use it.
 
 The comment gets a 🚀 and the report says it is re-running, until the new
-results replace it.
+results replace it. It only works once the first report has been posted —
+before that there is nothing to re-run, so wait for the initial check.

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ the run summary carries the same report.
 
 ### Re-running the checks
 
-Fixed something in your app's repo? Comment `/refresh` — on its own, as the
+Fixed something in your app's repo? Comment `/rereview` — on its own, as the
 whole comment — and the checks re-run against your repo's current code. No new
 commit is needed here, since `apps.json` hasn't changed. The PR author and
 anyone with write access can use it.

--- a/README.md
+++ b/README.md
@@ -120,3 +120,6 @@ Fixed something in your app's repo? Comment `/rereview` — on its own, as the
 whole comment — and the checks re-run against your repo's current code. No new
 commit is needed here, since `apps.json` hasn't changed. The PR author and
 anyone with write access can use it.
+
+The comment gets a 🚀 and the report says it is re-running, until the new
+results replace it.

--- a/validation/utils/report.py
+++ b/validation/utils/report.py
@@ -97,7 +97,7 @@ class Report:
         stamp = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M UTC")
         run = f" · [run log]({self.run_url})" if self.run_url else ""
         return (
-            f"<sub>Updated {stamp}{run} — fixed something in your app? Comment `/refresh` "
+            f"<sub>Updated {stamp}{run} — fixed something in your app? Comment `/rereview` "
             "to run these checks again. See "
             "[what CI checks](https://github.com/frappe/marketplace/blob/main/README.md#what-ci-checks)"
             ".</sub>"


### PR DESCRIPTION
Renames `/refresh` to `/rereview` and tightens how the command behaves.

- **`/refresh` → `/rereview`** throughout — workflow, script, report footer, README. The old name stops working once this merges.
- **One reaction, not two.** The 👀 was never visible: the job dispatches within seconds, so it was added and deleted before anyone saw it. A command now gets 🚀 on success, or 😕 if refused.
- **A repeat command does nothing.** While a run is still going, a second `/rereview` would queue a duplicate over the one already producing the answer. It now reacts and stops — no extra run, no comment.
- **Only works after the first report is published.** Before that there is nothing to re-run — the initial check is either still going or never started — so the command declines and says to wait.

Behaviour is otherwise unchanged: exact-match trigger, PR author or write access only, and the run must be attributable to this PR.