### PR TITLE
feat: Add frappe suite to marketplace

### DIFF
--- a/apps.json
+++ b/apps.json
@@ -1791,5 +1791,20 @@
     "category": "Applications",
     "stars": 501,
     "releases": "apps/health.json"
+  },
+  {
+    "name": "suite",
+    "title": "Frappe Suite",
+    "description": "Original, intentionally designed productivity tools",
+    "repo": "https://github.com/frappe/suite",
+    "logo_url": "https://raw.githubusercontent.com/frappe/suite/develop/frontend/public/logo.svg",
+    "website": "https://frappe.io",
+    "documentation": "https://docs.frappe.io",
+    "categories": [
+      "Productivity"
+    ],
+    "category": "Applications",
+    "stars": 56,
+    "releases": "apps/suite.json"
   }
 ]

--- a/apps/suite.json
+++ b/apps/suite.json
@@ -1,0 +1,13 @@
+{
+  "name": "suite",
+  "releases": [
+    {
+      "version": "0.0.1",
+      "branch": "develop",
+      "commit": "df0b1065f497f225cc3226ba31c50954ded6973a",
+      "frappe_core": ">=16.0.0,<18.0.0",
+      "dependencies": {},
+      "channel": "stable"
+    }
+  ]
+}


### PR DESCRIPTION
Adds [frappe/suite](https://github.com/frappe/suite) to the registry in the commit-scoped format, and exercises the checks end to end on a base that is already split (#14).

Replaces #6, which was written against the old `targets` format and no longer validates.

### Entry

- `apps.json` — metadata plus `"releases": "apps/suite.json"`
- `apps/suite.json` — one release: `develop` @ `df0b1065f497f225cc3226ba31c50954ded6973a`
- `version` `0.0.1` and `frappe_core` `>=16.0.0,<18.0.0` both come from `[tool.bench.frappe-dependencies]` / `[project]` in `pyproject.toml` at that commit, which the get-app check re-reads and compares
- `channel: stable` — `develop` is suite's only release line, so it is not a nightly build alongside cut release branches

### What CI should do here

Only this one release is new, so `validation/check.py` should scan exactly `suite@df0b1065` and nothing else: clone at that commit (rejecting it if unreachable from `develop`), then semgrep, then the get-app validator.

Verified locally against `main`'s own `validation/`: schema clean, `find_changed_releases` returns just this release, and the clone lands on `df0b1065` with the ancestry check passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)